### PR TITLE
Fix: Passing props to cells

### DIFF
--- a/demo/src/HeaderCell.js
+++ b/demo/src/HeaderCell.js
@@ -1,14 +1,18 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-class HeaderCell extends Component {
+export default class HeaderCell extends Component {
   static propTypes = {
     title: PropTypes.string
   };
+
   render() {
     const { title } = this.props;
-    return <div>{title}</div>;
+
+    return (
+      <div>
+        <strong>{title}</strong>
+      </div>
+    );
   }
 }
-
-export default HeaderCell;

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -21,10 +21,6 @@ export default class App extends Component {
     selectedRows: []
   };
 
-  headerRenderer = props => {
-    return <HeaderCell {...props} />;
-  };
-
   //eslint-disable-next-line
   handleSort = column => {};
 
@@ -49,7 +45,7 @@ export default class App extends Component {
             title="Name"
             width={200}
             dataKey="name"
-            headerRenderer={this.headerRenderer}
+            headerRenderer={HeaderCell}
           />
           <Column title="Age" width={50} dataKey="age" />
           <Column title="Gender" width={75} dataKey="gender" />

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -30,6 +30,10 @@ export default class App extends Component {
     });
   };
 
+  renderCheckbox = ({ checkbox }) => {
+    return <span>{checkbox}</span>;
+  };
+
   render() {
     const { rows, selectedRows } = this.state;
 
@@ -40,6 +44,7 @@ export default class App extends Component {
           fixed={4}
           onRowCheck={this.handleRowCheck}
           selectedRows={selectedRows}
+          checkboxRenderer={this.renderCheckbox}
         >
           <Column
             title="Name"

--- a/src/components/CheckboxCell/index.js
+++ b/src/components/CheckboxCell/index.js
@@ -6,25 +6,30 @@ import { cellPropKeys } from '../../constants';
 
 import { renderElement } from '../../util';
 
-class CheckboxCell extends Component {
+export default class CheckboxCell extends Component {
   handleCellCheck = () => {
-    this.props.onCheck(this.props.id);
+    const { onCheck, id } = this.props;
+
+    onCheck(id);
   };
 
   render() {
     const { id, renderer, isChecked } = this.props;
+    const onChange = this.handleCellCheck;
+
+    const checkbox = (
+      <input
+        type="checkbox"
+        id={id}
+        checked={isChecked}
+        onChange={this.handleCellCheck}
+      />
+    );
 
     return renderElement(
       renderer,
-      pick(this.props, cellPropKeys),
-      <div>
-        <input
-          type="checkbox"
-          id={id}
-          checked={isChecked}
-          onChange={this.handleCellCheck}
-        />
-      </div>
+      { ...pick(this.props, cellPropKeys), checkbox, onChange, isChecked },
+      <div>{checkbox}</div>
     );
   }
 }
@@ -34,5 +39,3 @@ CheckboxCell.propTypes = {
   isChecked: PropTypes.bool.isRequired,
   renderer: PropTypes.func
 };
-
-export default CheckboxCell;

--- a/src/components/CheckboxCell/index.js
+++ b/src/components/CheckboxCell/index.js
@@ -4,6 +4,8 @@ import { pick } from 'lodash';
 
 import { cellPropKeys } from '../../constants';
 
+import { renderElement } from '../../util';
+
 class CheckboxCell extends Component {
   handleCellCheck = () => {
     this.props.onCheck(this.props.id);
@@ -12,10 +14,10 @@ class CheckboxCell extends Component {
   render() {
     const { id, renderer, isChecked } = this.props;
 
-    return renderer ? (
-      renderer(pick(this.props, cellPropKeys))
-    ) : (
-      <div className="">
+    return renderElement(
+      renderer,
+      pick(this.props, cellPropKeys),
+      <div>
         <input
           type="checkbox"
           id={id}

--- a/src/components/CheckboxCell/index.js
+++ b/src/components/CheckboxCell/index.js
@@ -29,7 +29,7 @@ export default class CheckboxCell extends Component {
     return renderElement(
       renderer,
       { ...pick(this.props, cellPropKeys), checkbox, onChange, isChecked },
-      <div>{checkbox}</div>
+      checkbox
     );
   }
 }

--- a/src/components/ColumnSwitcher/index.js
+++ b/src/components/ColumnSwitcher/index.js
@@ -2,6 +2,9 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 import { columnSwitcherStyle } from '../../styles/column.styles';
+import { RendererType } from '../../constants';
+
+import { renderElement } from '../../util';
 
 class ColumnSwitcher extends Component {
   state = {
@@ -55,7 +58,7 @@ class ColumnSwitcher extends Component {
   };
 
   render() {
-    const { columns, onChange } = this.props;
+    const { columns, onChange, checkboxRenderer } = this.props;
 
     return (
       <div
@@ -76,22 +79,33 @@ class ColumnSwitcher extends Component {
           >
             {columns
               .filter(({ isCheckbox }) => !isCheckbox)
-              .map(({ title, dataKey, visible }) => {
+              .map(({ title, dataKey, visible: isChecked }) => {
+                const checkbox = (
+                  <label htmlFor={dataKey}>
+                    <input
+                      type="checkbox"
+                      id={dataKey}
+                      name="column"
+                      onChange={onChange}
+                      checked={isChecked}
+                    />
+                    {title}
+                  </label>
+                );
+
                 return (
                   <div
                     className="Sticky-React-Table--Header-Column-Switcher-Item"
                     key={title}
                   >
-                    <label htmlFor={dataKey}>
-                      <input
-                        type="checkbox"
-                        id={dataKey}
-                        name="column"
-                        onChange={onChange}
-                        checked={visible}
-                      />
-                      {title}
-                    </label>
+                    {renderElement(checkboxRenderer, {
+                      checkbox,
+                      id: dataKey,
+                      dataKey,
+                      onChange,
+                      isChecked,
+                      type: 'columnSwitcher'
+                    })}
                   </div>
                 );
               })}
@@ -104,7 +118,8 @@ class ColumnSwitcher extends Component {
 
 ColumnSwitcher.propTypes = {
   columns: PropTypes.array.isRequired,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  checkboxRenderer: RendererType
 };
 
 export default ColumnSwitcher;

--- a/src/components/Rows/Cells/Cell.js
+++ b/src/components/Rows/Cells/Cell.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 
 import CheckboxCell from '../../CheckboxCell';
 
-import { cellPropKeys } from '../../../constants';
+import { cellPropKeys, RendererType } from '../../../constants';
 
 import { getCellStyle, renderElement } from '../../../util';
 
@@ -26,7 +26,8 @@ export default class Cell extends PureComponent {
       isChecked,
       onCheck,
       isCheckbox,
-      className
+      className,
+      checkboxRenderer
     } = this.props;
 
     return (
@@ -40,7 +41,7 @@ export default class Cell extends PureComponent {
         {isCheckbox ? (
           <CheckboxCell
             id={id}
-            renderer={renderer}
+            renderer={checkboxRenderer}
             onCheck={onCheck}
             isChecked={isChecked}
           />
@@ -78,7 +79,8 @@ Cell.propTypes = {
   isChecked: PropTypes.bool.isRequired,
   isCheckbox: PropTypes.bool.isRequired,
   onCheck: PropTypes.func.isRequired,
-  className: PropTypes.string
+  className: PropTypes.string,
+  checkboxRenderer: RendererType
 };
 
 Cell.defaultProps = {

--- a/src/components/Rows/Cells/Cell.js
+++ b/src/components/Rows/Cells/Cell.js
@@ -33,7 +33,8 @@ export default class Cell extends PureComponent {
     return (
       <div
         className={classNames(className, 'Sticky-React-Table--Row-Cell', {
-          'Sticky-React-Table--is-Sticky--is-Last': isLastSticky
+          'Sticky-React-Table--is-Sticky--is-Last': isLastSticky,
+          'Sticky-React-Table--Row-Cell-Checkbox': isCheckbox
         })}
         style={getCellStyle(style, isSticky)}
         tabIndex={0}

--- a/src/components/Rows/Cells/Cell.js
+++ b/src/components/Rows/Cells/Cell.js
@@ -61,15 +61,12 @@ export default class Cell extends PureComponent {
 }
 
 Cell.propTypes = {
+  dataKey: PropTypes.string,
   cellData: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
+    PropTypes.node,
     PropTypes.bool,
     PropTypes.func,
-    PropTypes.element,
-    PropTypes.node,
-    PropTypes.object,
-    PropTypes.array
+    PropTypes.object
   ]),
   style: PropTypes.object.isRequired,
   isSticky: PropTypes.bool,

--- a/src/components/Rows/Cells/Cell.js
+++ b/src/components/Rows/Cells/Cell.js
@@ -7,7 +7,7 @@ import CheckboxCell from '../../CheckboxCell';
 
 import { cellPropKeys } from '../../../constants';
 
-import { getCellStyle } from '../../../util';
+import { getCellStyle, renderElement } from '../../../util';
 
 export default class Cell extends PureComponent {
   handleDragHandleRef = ref => {
@@ -46,7 +46,8 @@ export default class Cell extends PureComponent {
           />
         ) : (
           <Fragment>
-            {renderer ? renderer(pick(this.props, cellPropKeys)) : cellData}
+            {renderElement(renderer, pick(this.props, cellPropKeys), cellData)}
+
             <div
               className="Sticky-React-Table-Resize-Handler"
               draggable={true}

--- a/src/components/Rows/Cells/HeaderCell.js
+++ b/src/components/Rows/Cells/HeaderCell.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 
 import CheckboxCell from '../../CheckboxCell';
 
-import { headerCellPropKeys } from '../../../constants';
+import { headerCellPropKeys, RendererType } from '../../../constants';
 
 import { getCellStyle, renderElement } from '../../../util';
 
@@ -35,7 +35,8 @@ export default class HeaderCell extends PureComponent {
       checkedRows,
       onCheck,
       isCheckbox,
-      isAllSelected
+      isAllSelected,
+      checkboxRenderer
     } = this.props;
     const isSorted = sortedColumn && sortedColumn.dataKey === dataKey;
     const sortDir = sortedColumn ? sortedColumn.dir : '';
@@ -51,7 +52,7 @@ export default class HeaderCell extends PureComponent {
         {isCheckbox ? (
           <CheckboxCell
             id={id}
-            renderer={renderer}
+            renderer={checkboxRenderer}
             checkedRows={checkedRows}
             onCheck={onCheck}
             isChecked={isAllSelected}
@@ -103,7 +104,8 @@ HeaderCell.propTypes = {
   checkedRows: PropTypes.array.isRequired,
   onCheck: PropTypes.func.isRequired,
   isCheckbox: PropTypes.bool.isRequired,
-  isAllSelected: PropTypes.bool.isRequired
+  isAllSelected: PropTypes.bool.isRequired,
+  checkboxRenderer: RendererType
 };
 
 HeaderCell.defaultProps = {

--- a/src/components/Rows/Cells/HeaderCell.js
+++ b/src/components/Rows/Cells/HeaderCell.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 
 import CheckboxCell from '../../CheckboxCell';
 
-import { cellPropKeys } from '../../../constants';
+import { headerCellPropKeys } from '../../../constants';
 
 import { getCellStyle } from '../../../util';
 
@@ -15,8 +15,10 @@ export default class HeaderCell extends PureComponent {
   };
 
   handleSort = () => {
-    this.props.onSort(pick(this.props, cellPropKeys));
+    this.props.onSort(this.getRequiredProps());
   };
+
+  getRequiredProps = () => pick(this.props, headerCellPropKeys);
 
   render() {
     const {
@@ -56,7 +58,7 @@ export default class HeaderCell extends PureComponent {
           />
         ) : (
           <Fragment>
-            {renderer ? renderer(pick(this.props, cellPropKeys)) : title}
+            {renderer ? renderer(this.getRequiredProps()) : title}
             <div
               className="Sticky-React-Table-Resize-Handler"
               draggable={true}

--- a/src/components/Rows/Cells/HeaderCell.js
+++ b/src/components/Rows/Cells/HeaderCell.js
@@ -7,7 +7,7 @@ import CheckboxCell from '../../CheckboxCell';
 
 import { headerCellPropKeys } from '../../../constants';
 
-import { getCellStyle } from '../../../util';
+import { getCellStyle, renderElement } from '../../../util';
 
 export default class HeaderCell extends PureComponent {
   handleDragHandleRef = ref => {
@@ -58,13 +58,15 @@ export default class HeaderCell extends PureComponent {
           />
         ) : (
           <Fragment>
-            {renderer ? renderer(this.getRequiredProps()) : title}
+            {renderElement(renderer, this.getRequiredProps(), title)}
+
             <div
               className="Sticky-React-Table-Resize-Handler"
               draggable={true}
               onDragEnd={onDragEnd}
               ref={this.handleDragHandleRef}
             />
+
             {isSortable &&
               isSorted && (
                 <div className="Sticky-React-Table-Sort-Icon">

--- a/src/components/Rows/Cells/HeaderCell.js
+++ b/src/components/Rows/Cells/HeaderCell.js
@@ -44,7 +44,8 @@ export default class HeaderCell extends PureComponent {
     return (
       <div
         className={classNames('Sticky-React-Table--Header-Cell', {
-          'Sticky-React-Table--is-Sticky--is-Last': isLastSticky
+          'Sticky-React-Table--is-Sticky--is-Last': isLastSticky,
+          'Sticky-React-Table--Header-Cell-Checkbox': isCheckbox
         })}
         style={getCellStyle(style, isSticky)}
         onClick={this.handleSort}

--- a/src/components/Rows/HeaderRow.js
+++ b/src/components/Rows/HeaderRow.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import { HeaderCell } from './Cells';
 
 import { headerStyles } from '../../styles/row.styles';
+import { RendererType } from '../../constants';
 
 export default class HeaderRow extends PureComponent {
   renderColumns = () => {
@@ -18,7 +19,8 @@ export default class HeaderRow extends PureComponent {
       sortedColumn,
       checkedRows,
       onCheck,
-      isAllSelected
+      isAllSelected,
+      checkboxRenderer
     } = this.props;
 
     return columns.map((column, cellIndex) => {
@@ -56,6 +58,7 @@ export default class HeaderRow extends PureComponent {
           onDragEnd={onDragEnd(cellIndex)}
           key={`sitcky-table-header-${cellIndex}`}
           id="all"
+          checkboxRenderer={isCheckbox ? checkboxRenderer : null}
         />
       );
     });
@@ -87,5 +90,6 @@ HeaderRow.propTypes = {
   checkedRows: PropTypes.array.isRequired,
   onCheck: PropTypes.func.isRequired,
   isAllSelected: PropTypes.bool.isRequired,
-  className: PropTypes.string
+  className: PropTypes.string,
+  checkboxRenderer: RendererType
 };

--- a/src/components/Rows/HeaderRow.js
+++ b/src/components/Rows/HeaderRow.js
@@ -21,40 +21,41 @@ export default class HeaderRow extends PureComponent {
       isAllSelected
     } = this.props;
 
-    return columns.map((column, index) => {
+    return columns.map((column, cellIndex) => {
       const {
         title,
         width,
         dataKey,
-        headerRenderer,
+        headerRenderer: renderer,
         isSortable,
         isCheckbox
       } = column;
-      const style = { width, ...styleCalculator(index) };
-      const { isSticky, isLastSticky } = stickyFunction(index);
+      const style = { width, ...styleCalculator(cellIndex) };
+      const { isSticky, isLastSticky } = stickyFunction(cellIndex);
 
       return (
         <HeaderCell
-          title={title}
-          width={width}
-          dataKey={dataKey}
-          index={index}
-          style={style}
-          isSticky={isSticky}
-          isLastSticky={isLastSticky}
-          renderer={headerRenderer}
-          cellIndex={index}
-          rowIndex={rowIndex}
-          onDragEnd={onDragEnd(index)}
-          key={`sitcky-table-header-${index}`}
-          isSortable={isSortable}
-          onSort={onSort}
-          sortedColumn={sortedColumn}
+          {...{
+            title,
+            width,
+            dataKey,
+            cellIndex,
+            style,
+            isSticky,
+            isLastSticky,
+            renderer,
+            rowIndex,
+            isSortable,
+            onSort,
+            sortedColumn,
+            checkedRows,
+            onCheck,
+            isCheckbox,
+            isAllSelected
+          }}
+          onDragEnd={onDragEnd(cellIndex)}
+          key={`sitcky-table-header-${cellIndex}`}
           id="all"
-          checkedRows={checkedRows}
-          onCheck={onCheck}
-          isCheckbox={isCheckbox}
-          isAllSelected={isAllSelected}
         />
       );
     });

--- a/src/components/Rows/Row.js
+++ b/src/components/Rows/Row.js
@@ -7,6 +7,8 @@ import { Cell } from './Cells';
 
 import { rowPropKeys } from '../../constants';
 
+import { renderElement } from '../../util';
+
 import { rowStyles } from '../../styles/row.styles';
 
 export default class Row extends PureComponent {
@@ -91,8 +93,8 @@ export default class Row extends PureComponent {
   render() {
     const { renderer } = this.props;
 
-    if (typeof renderer === 'function') {
-      const row = renderer({
+    if (renderer) {
+      const row = renderElement(renderer, {
         ...pick(this.props, rowPropKeys),
         renderColumns: this.renderColumns,
         defaultRowRenderer: this.defaultRowRenderer

--- a/src/components/Rows/Row.js
+++ b/src/components/Rows/Row.js
@@ -23,30 +23,39 @@ export default class Row extends PureComponent {
       isChecked
     } = this.props;
 
-    return columns.map((column, index) => {
-      const { width, dataKey, cellRenderer, isCheckbox, className } = column;
+    return columns.map((column, cellIndex) => {
+      const {
+        width,
+        dataKey,
+        cellRenderer: renderer,
+        isCheckbox,
+        className
+      } = column;
+
       const cellData = get(rowData, dataKey);
-      const style = { width, ...styleCalculator(index) };
-      const { isSticky, isLastSticky } = stickyFunction(index);
+      const style = { width, ...styleCalculator(cellIndex) };
+      const { isSticky, isLastSticky } = stickyFunction(cellIndex);
 
       return (
         <Cell
-          dataKey={dataKey}
-          cellData={cellData}
-          rowData={rowData}
-          style={style}
-          renderer={cellRenderer}
-          cellIndex={index}
-          rowIndex={rowIndex}
-          isSticky={isSticky}
-          isLastSticky={isLastSticky}
-          onDragEnd={onDragEnd(index)}
-          key={`sitcky-table-row-${rowIndex}-${index}`}
-          id={id}
-          onCheck={onCheck}
-          isCheckbox={isCheckbox}
-          isChecked={isChecked}
-          className={className}
+          {...{
+            id,
+            dataKey,
+            cellData,
+            rowData,
+            rowIndex,
+            style,
+            isSticky,
+            isLastSticky,
+            onCheck,
+            isCheckbox,
+            isChecked,
+            className,
+            renderer,
+            cellIndex
+          }}
+          onDragEnd={onDragEnd(cellIndex)}
+          key={`sitcky-table-row-${rowIndex}-${cellIndex}`}
         />
       );
     });

--- a/src/components/Rows/Row.js
+++ b/src/components/Rows/Row.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 
 import { Cell } from './Cells';
 
-import { rowPropKeys } from '../../constants';
+import { RendererType, rowPropKeys } from '../../constants';
 
 import { renderElement } from '../../util';
 
@@ -22,7 +22,8 @@ export default class Row extends PureComponent {
       onDragEnd,
       onCheck,
       id,
-      isChecked
+      isChecked,
+      checkboxRenderer
     } = this.props;
 
     return columns.map((column, cellIndex) => {
@@ -58,6 +59,7 @@ export default class Row extends PureComponent {
           }}
           onDragEnd={onDragEnd(cellIndex)}
           key={`sitcky-table-row-${rowIndex}-${cellIndex}`}
+          checkboxRenderer={isCheckbox ? checkboxRenderer : null}
         />
       );
     });
@@ -120,5 +122,6 @@ Row.propTypes = {
   onCheck: PropTypes.func.isRequired,
   rowClassName: PropTypes.func,
   renderer: PropTypes.func,
-  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired
+  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  checkboxRenderer: RendererType
 };

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -4,7 +4,7 @@ import React, { PureComponent } from 'react';
 import { Row, HeaderRow } from './Rows';
 import ColumnSwitcher from './ColumnSwitcher';
 
-import { ColumnDisplayName } from '../constants';
+import { ColumnDisplayName, RendererType } from '../constants';
 import Errors from './Errors';
 
 import { sort } from '../util';
@@ -21,7 +21,7 @@ export default class Table extends PureComponent {
     data: PropTypes.array.isRequired,
     onSort: PropTypes.func,
     rowSelection: PropTypes.bool,
-    checkboxRenderer: PropTypes.node,
+    checkboxRenderer: RendererType,
     onRowCheck: PropTypes.func,
     idKey: PropTypes.string,
     rowClassName: PropTypes.func,
@@ -308,10 +308,12 @@ export default class Table extends PureComponent {
   handleDragEnd = columnIndex => e => {
     const widthDiff = e.clientX - e.target.getBoundingClientRect().left;
     const newColumns = [...this.state.columns];
+
     newColumns[columnIndex] = {
       ...newColumns[columnIndex],
       width: newColumns[columnIndex].width + widthDiff
     };
+
     this.setState({
       columns: newColumns
     });
@@ -323,6 +325,7 @@ export default class Table extends PureComponent {
 
   render() {
     const { columns } = this.state;
+    const { checkboxRenderer } = this.props;
 
     return (
       <div className="Sticky-React-Table" style={mainContainerStyle}>
@@ -330,8 +333,9 @@ export default class Table extends PureComponent {
           {this.headerRenderer()}
           {this.bodyRenderer()}
         </div>
+
         <ColumnSwitcher
-          columns={columns}
+          {...{ checkboxRenderer, columns }}
           onChange={this.handleColumnVisibilityChange}
         />
       </div>

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,6 +12,8 @@ export const cellPropKeys = [
   'isAllSelected'
 ];
 
+export const headerCellPropKeys = [...cellPropKeys, 'isSortable'];
+
 export const rowPropKeys = [
   'id',
   'rowData',

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,6 +3,7 @@ export const ColumnDisplayName = 'Column';
 export const cellPropKeys = [
   'id',
   'rowData',
+  'dataKey',
   'cellData',
   'isChecked',
   'isCheckbox',

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types';
+
 export const ColumnDisplayName = 'Column';
 
 export const cellPropKeys = [
@@ -9,7 +11,8 @@ export const cellPropKeys = [
   'isCheckbox',
   'style',
   'title',
-  'isAllSelected'
+  'isAllSelected',
+  'checkboxRenderer'
 ];
 
 export const headerCellPropKeys = [...cellPropKeys, 'isSortable'];
@@ -21,3 +24,8 @@ export const rowPropKeys = [
   'columns',
   'isChecked'
 ];
+
+export const RendererType = PropTypes.oneOfType([
+  PropTypes.node,
+  PropTypes.func
+]);

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { orderBy } from 'lodash';
 
 import { defaultCellStyle, stickyCellStyle } from '../styles/cell.styles';
@@ -31,3 +32,13 @@ export function getCellStyle(style, isSticky) {
 
   return cellStyle;
 }
+
+export const renderElement = (element, props, defaultRenderer) => {
+  if (!element) {
+    return defaultRenderer;
+  }
+
+  return React.isValidElement(element)
+    ? React.cloneElement(element, props)
+    : React.createElement(element, props);
+};


### PR DESCRIPTION
Fixes:
- passing `dataKey` to header and body cells
- passing `isSortable` to header cells

Implements:
- custom renderers for checkboxes (both table and column switcher)
- support of class components as cell/header renderers without the need in wrapping in a function