### PR TITLE
Fix: Column Switcher Key

### DIFF
--- a/src/components/ColumnSwitcher/index.js
+++ b/src/components/ColumnSwitcher/index.js
@@ -106,6 +106,7 @@ class ColumnSwitcher extends Component {
                         dataKey,
                         onChange,
                         isChecked,
+                        title,
                         type: 'columnSwitcher'
                       },
                       checkbox

--- a/src/components/ColumnSwitcher/index.js
+++ b/src/components/ColumnSwitcher/index.js
@@ -79,7 +79,7 @@ class ColumnSwitcher extends Component {
           >
             {columns
               .filter(({ isCheckbox }) => !isCheckbox)
-              .map(({ title, dataKey, visible: isChecked }) => {
+              .map(({ title, dataKey, visible: isChecked }, index) => {
                 const checkbox = (
                   <label htmlFor={dataKey}>
                     <input
@@ -96,16 +96,20 @@ class ColumnSwitcher extends Component {
                 return (
                   <div
                     className="Sticky-React-Table--Header-Column-Switcher-Item"
-                    key={title}
+                    key={title || dataKey || index}
                   >
-                    {renderElement(checkboxRenderer, {
-                      checkbox,
-                      id: dataKey,
-                      dataKey,
-                      onChange,
-                      isChecked,
-                      type: 'columnSwitcher'
-                    })}
+                    {renderElement(
+                      checkboxRenderer,
+                      {
+                        checkbox,
+                        id: dataKey,
+                        dataKey,
+                        onChange,
+                        isChecked,
+                        type: 'columnSwitcher'
+                      },
+                      checkbox
+                    )}
                   </div>
                 );
               })}


### PR DESCRIPTION
`title` isn't a required prop and might not be set for certain columns, so it's required to use some other prop as a key. Otherwise it throws an error.