### PR TITLE
Column Switcher: Improvements

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -51,6 +51,7 @@ export default class App extends Component {
             width={200}
             dataKey="name"
             headerRenderer={HeaderCell}
+            alwaysVisible
           />
           <Column title="Age" width={50} dataKey="age" />
           <Column title="Gender" width={75} dataKey="gender" />

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "lodash": "^4.17.10",
+    "memoize-one": "^4.0.0",
     "prop-types": "^15.6.2"
   },
   "peerDependencies": {

--- a/src/components/Column.js
+++ b/src/components/Column.js
@@ -1,7 +1,19 @@
+import PropTypes from 'prop-types';
+
 import { ColumnDisplayName } from '../constants';
 
-export default function Column() {
+const Column = () => {
   return null;
-}
+};
+
+Column.propTypes = {
+  alwaysVisible: PropTypes.bool
+};
+
+Column.defaultProps = {
+  alwaysVisible: false
+};
 
 Column.displayName = ColumnDisplayName;
+
+export default Column;

--- a/src/components/ColumnSwitcher/ColumnSwitcherItem.js
+++ b/src/components/ColumnSwitcher/ColumnSwitcherItem.js
@@ -1,0 +1,60 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import { RendererType } from '../../constants';
+
+import { renderElement } from '../../util';
+
+export default class ColumnSwitcherItem extends Component {
+  static propTypes = {
+    title: PropTypes.string.isRequired,
+    dataKey: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    isChecked: PropTypes.bool.isRequired,
+    checkboxRenderer: RendererType
+  };
+
+  handleChange = () => {
+    const { onChange, dataKey } = this.props;
+
+    onChange(dataKey);
+  };
+
+  render() {
+    const { dataKey, isChecked, title, checkboxRenderer } = this.props;
+
+    const onChange = this.handleChange;
+
+    const checkbox = (
+      <label htmlFor={dataKey}>
+        <input
+          type="checkbox"
+          id={dataKey}
+          name="column"
+          onChange={onChange}
+          checked={isChecked}
+        />
+
+        {title}
+      </label>
+    );
+
+    return (
+      <div className="Sticky-React-Table--Header-Column-Switcher-Item">
+        {renderElement(
+          checkboxRenderer,
+          {
+            checkbox,
+            id: dataKey,
+            dataKey,
+            onChange,
+            isChecked,
+            title,
+            type: 'columnSwitcher'
+          },
+          checkbox
+        )}
+      </div>
+    );
+  }
+}

--- a/src/components/ColumnSwitcher/index.js
+++ b/src/components/ColumnSwitcher/index.js
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import memoize from 'memoize-one';
+
+import ColumnSwitcherItem from './ColumnSwitcherItem';
 
 import { columnSwitcherStyle } from '../../styles/column.styles';
 import { RendererType } from '../../constants';
-
-import { renderElement } from '../../util';
 
 class ColumnSwitcher extends Component {
   state = {
@@ -57,8 +58,20 @@ class ColumnSwitcher extends Component {
     }
   };
 
+  getSwitchableColumns = memoize(columns =>
+    columns.filter(
+      column =>
+        !column.isCheckbox &&
+        !column.alwaysVisible &&
+        column.dataKey &&
+        column.title
+    )
+  );
+
   render() {
-    const { columns, onChange, checkboxRenderer } = this.props;
+    let { onChange, checkboxRenderer, columns } = this.props;
+
+    columns = this.getSwitchableColumns(columns);
 
     return (
       <div
@@ -72,48 +85,24 @@ class ColumnSwitcher extends Component {
         >
           :
         </div>
+
         {this.state.visible && (
           <div
             className="Sticky-React-Table--Header-Column-Switcher-Dropdown"
             ref={this.handleMenuRef}
           >
-            {columns
-              .filter(({ isCheckbox }) => !isCheckbox)
-              .map(({ title, dataKey, visible: isChecked }, index) => {
-                const checkbox = (
-                  <label htmlFor={dataKey}>
-                    <input
-                      type="checkbox"
-                      id={dataKey}
-                      name="column"
-                      onChange={onChange}
-                      checked={isChecked}
-                    />
-                    {title}
-                  </label>
-                );
-
-                return (
-                  <div
-                    className="Sticky-React-Table--Header-Column-Switcher-Item"
-                    key={title || dataKey || index}
-                  >
-                    {renderElement(
-                      checkboxRenderer,
-                      {
-                        checkbox,
-                        id: dataKey,
-                        dataKey,
-                        onChange,
-                        isChecked,
-                        title,
-                        type: 'columnSwitcher'
-                      },
-                      checkbox
-                    )}
-                  </div>
-                );
-              })}
+            {columns.map(({ title, dataKey, visible: isChecked }) => (
+              <ColumnSwitcherItem
+                key={dataKey}
+                {...{
+                  isChecked,
+                  title,
+                  dataKey,
+                  onChange,
+                  checkboxRenderer
+                }}
+              />
+            ))}
           </div>
         )}
       </div>

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -180,23 +180,19 @@ export default class Table extends PureComponent {
     return this.props.data.length === this.getCheckedRows().length;
   };
 
-  handleColumnVisibilityChange = ({ target: { id } }) => {
-    const ind = this.state.columns.findIndex(col => col.dataKey === id);
-    if (ind !== -1) {
-      const oldVisibility = this.state.columns[ind].visible;
-      const newColumns = [
-        ...this.state.columns.slice(0, ind),
-        {
-          ...this.state.columns[ind],
-          visible: !oldVisibility
-        },
-        ...this.state.columns.slice(ind + 1)
-      ];
+  handleColumnVisibilityChange = dataKey => {
+    this.setState(({ columns }) => ({
+      columns: columns.map(column => {
+        if (column.dataKey === dataKey) {
+          return {
+            ...column,
+            visible: !column.visible
+          };
+        }
 
-      this.setState({
-        columns: newColumns
-      });
-    }
+        return column;
+      })
+    }));
   };
 
   headerRenderer = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5132,6 +5132,10 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+memoize-one@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.0.tgz#fc5e2f1427a216676a62ec652cf7398cfad123db"
+
 memory-fs@^0.4.0, memory-fs@^0.4.1, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"


### PR DESCRIPTION
This PR:
- changes the implementation so that onChange handler operates with dataKey rather than checkbox id
- adds support for alwaysVisible column prop to disable hidning of certain columns
- contains fixes to exclude columns with no title/dataKey provided from displaying in column switcher list