### PR TITLE
Fix: Infinite Loader Threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,22 +121,22 @@ Sticky React Table supports a host of properties which allow you to completely c
 
 #### Properties:
 
-| Property                     | Type                 | Default     | Description                                                                     | Required |
-| ----------------------       | ---------------------| ----------- | ------------------------------------------------------------------------------- | -------- |
-| data                         | `Array`              | `undefined` | The array of data to be used by the table to render rows and cells.             | **Yes**  |
-| children                     | `Column`             | `undefined` | The `Column` component. It does not accept any other children.                  | **Yes**  |
-| fixed                        | `Number`             | `undefined` | The number of fixed columns in the table.                                       | No       |
-| rowSelection                 | `Bool`               | `true`      | This property determines whether checkbox column is rendered.                   | No       |
-| idKey                        | `String`             | `id`        | A key used to uniquely identify data.                                           | No       |
-| rowClassName                 | `String`             | `undefined` | Custom classes for a row.                                                       | No       |
-| headerClassName              | `String`             | `undefined` | Custom classes for the header row.                                              | No       |
-| selectedRows                 | `Array`              | `undefined` | An array of ids to make the table act as a controlled selection component.      | No       |
-| infiniteScrollTotalCount     | `Number`             | `undefined` | Total number of rows which can be loaded using infinite loader.                 | No       |
-| infiniteScrollLoadMore       | `Function`           | `undefined` | Invoked when a new page is requested when using infinite loader.                | No       |
-| infiniteScrollThreshold      | `Number`             | `50`        | How much in percents to scroll until infiniteScrollLoadMore is invoked.                   | No       |
-| infiniteScrollLoaderRowCount | `Number`             | `5`         | The number of additional rows to display at the bottom for progress indication. | No       |
-| infiniteScrollPageSize       | `Number`             | `30`        | A number of rows loaded with each portion.                                      | No       |
-| infiniteScrollCellRenderer   | `Node` or `Function` | `undefined` | Custom content to dispaly within cells of additional loader rows.               | No       |
+| Property                     | Type                 | Default     | Description                                                                                         | Required |
+| ---------------------------- | ---------------------| ----------- | --------------------------------------------------------------------------------------------------- | -------- |
+| data                         | `Array`              | `undefined` | The array of data to be used by the table to render rows and cells.                                 | **Yes**  |
+| children                     | `Column`             | `undefined` | The `Column` component. It does not accept any other children.                                      | **Yes**  |
+| fixed                        | `Number`             | `undefined` | The number of fixed columns in the table.                                                           | No       |
+| rowSelection                 | `Bool`               | `true`      | This property determines whether checkbox column is rendered.                                       | No       |
+| idKey                        | `String`             | `id`        | A key used to uniquely identify data.                                                               | No       |
+| rowClassName                 | `String`             | `undefined` | Custom classes for a row.                                                                           | No       |
+| headerClassName              | `String`             | `undefined` | Custom classes for the header row.                                                                  | No       |
+| selectedRows                 | `Array`              | `undefined` | An array of ids to make the table act as a controlled selection component.                          | No       |
+| infiniteScrollTotalCount     | `Number`             | `undefined` | Total number of rows which can be loaded using infinite loader.                                     | No       |
+| infiniteScrollLoadMore       | `Function`           | `undefined` | Invoked when a new page is requested when using infinite loader.                                    | No       |
+| infiniteScrollThreshold      | `Number`             | `10`        | The number of rows before the end of the table that will trigger a call to infiniteScrollThreshold. | No       |
+| infiniteScrollLoaderRowCount | `Number`             | `5`         | The number of additional rows to display at the bottom for progress indication.                     | No       |
+| infiniteScrollPageSize       | `Number`             | `30`        | A number of rows loaded with each portion.                                                          | No       |
+| infiniteScrollCellRenderer   | `Node` or `Function` | `undefined` | Custom content to display within cells of additional loader rows.                                   | No       |
 
 #### Callbacks:
 

--- a/src/components/Rows/Row.js
+++ b/src/components/Rows/Row.js
@@ -26,7 +26,8 @@ export default class Row extends PureComponent {
     id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
     checkboxRenderer: RendererType,
     isLoaderRow: PropTypes.bool,
-    infiniteScrollCellRenderer: RendererType
+    infiniteScrollCellRenderer: RendererType,
+    getRef: PropTypes.func.isRequired
   };
 
   static defaultProps = {
@@ -91,11 +92,18 @@ export default class Row extends PureComponent {
     return '';
   };
 
+  getRef = ref => {
+    const { getRef, rowIndex } = this.props;
+
+    getRef(ref, rowIndex);
+  };
+
   defaultRowRenderer = () => {
     const { isChecked } = this.props;
 
     return (
       <div
+        ref={this.getRef}
         className={classNames(
           'Sticky-React-Table--Row',
           this.getRowClassNames(),

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -346,12 +346,14 @@ export default class Table extends PureComponent {
         unloadedRowCount
       );
 
+      const rowCount = rows.length;
+
       // generate fake loader row data (we basically only need some distinct ids)
       const loaderRowsData = times(loaderRowCount, index => ({
-        id: `sticky-react-loader-row-${index + 1}`
+        id: `sticky-react-loader-row-${rowCount + index + 1}`
       }));
 
-      return rows.concat(getRows(loaderRowsData, true, rows.length));
+      return rows.concat(getRows(loaderRowsData, true, rowCount));
     }
 
     return rows;

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -391,7 +391,7 @@ export default class Table extends PureComponent {
   };
 
   isInfiniteLoadingEnabled = () => {
-    return this.getUnloadedRowCount();
+    return !!this.getUnloadedRowCount();
   };
 
   handleScroll = ({ target }) => {
@@ -402,18 +402,16 @@ export default class Table extends PureComponent {
       data
     } = this.props;
 
-    if (this.isInfiniteLoadingEnabled()) {
-      const scrollPercentage =
-        (target.scrollTop / (target.scrollHeight - target.clientHeight)) * 100;
+    const scrollPercentage =
+      (target.scrollTop / (target.scrollHeight - target.clientHeight)) * 100;
 
-      if (scrollPercentage > infiniteScrollThreshold) {
-        const nextPage = data.length / infiniteScrollPageSize + 1;
+    if (scrollPercentage > infiniteScrollThreshold) {
+      const nextPage = data.length / infiniteScrollPageSize + 1;
 
-        if (!this.requestedPages[nextPage]) {
-          this.requestedPages[nextPage] = true;
+      if (!this.requestedPages[nextPage]) {
+        this.requestedPages[nextPage] = true;
 
-          infiniteScrollLoadMore(nextPage * infiniteScrollPageSize, last(data));
-        }
+        infiniteScrollLoadMore(nextPage * infiniteScrollPageSize, last(data));
       }
     }
   };
@@ -421,13 +419,14 @@ export default class Table extends PureComponent {
   render() {
     const { columns } = this.state;
     const { checkboxRenderer } = this.props;
+    const infiniteLoadingEnabled = this.isInfiniteLoadingEnabled();
 
     return (
       <div className="Sticky-React-Table" style={mainContainerStyle}>
         <div
           className="Sticky-React-Table-inner"
           style={innerContainerStyle}
-          onScroll={this.handleScroll}
+          onScroll={infiniteLoadingEnabled ? this.handleScroll : null}
         >
           {this.headerRenderer()}
           {this.bodyRenderer()}

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -294,11 +294,11 @@ export default class Table extends PureComponent {
 
     const columns = this.getVisibleColumns();
 
-    const getRows = (data, isLoaderRow) => {
+    const getRows = (data, isLoaderRow, startIndex = 0) => {
       return data.map((rowData, index) => {
         const id = rowData[idKey];
         const isChecked = this.isRowSelected(id);
-        const rowIndex = index + 1;
+        const rowIndex = startIndex + index + 1;
 
         return (
           <Row
@@ -344,7 +344,7 @@ export default class Table extends PureComponent {
         id: `sticky-react-loader-row-${index + 1}`
       }));
 
-      return rows.concat(getRows(loaderRowsData, true));
+      return rows.concat(getRows(loaderRowsData, true, rows.length));
     }
 
     return rows;


### PR DESCRIPTION
Improves the mechaninsm of calculating the threshold to be based on row index rather than on scroll percentage which could lead to false positives