### PR TITLE
Allow innerRef prop to pass table ref to parent component

### DIFF
--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -58,8 +58,7 @@ export default class Table extends PureComponent {
     infiniteScrollLoaderRowCount: 1,
     infiniteScrollPageSize: 30,
     infiniteScrollThreshold: 10,
-    infiniteScrollCellRenderer: DefaultInfiniteScrollCellRenderer,
-    innerRef: () => {}
+    infiniteScrollCellRenderer: DefaultInfiniteScrollCellRenderer
   };
 
   constructor(props) {
@@ -498,9 +497,10 @@ export default class Table extends PureComponent {
   };
 
   saveInnerRef = ref => {
-    this.innerRef = ref;
+    const { innerRef } = this.props;
 
-    this.props.innerRef(ref);
+    this.innerRef = ref;
+    innerRef && innerRef(ref);
   };
 
   render() {

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -48,7 +48,8 @@ export default class Table extends PureComponent {
     infiniteScrollThreshold: PropTypes.number,
     infiniteScrollLoaderRowCount: PropTypes.number,
     infiniteScrollPageSize: PropTypes.number,
-    infiniteScrollCellRenderer: RendererType
+    infiniteScrollCellRenderer: RendererType,
+    innerRef: PropTypes.func
   };
 
   static defaultProps = {
@@ -57,7 +58,8 @@ export default class Table extends PureComponent {
     infiniteScrollLoaderRowCount: 1,
     infiniteScrollPageSize: 30,
     infiniteScrollThreshold: 10,
-    infiniteScrollCellRenderer: DefaultInfiniteScrollCellRenderer
+    infiniteScrollCellRenderer: DefaultInfiniteScrollCellRenderer,
+    innerRef: () => {}
   };
 
   constructor(props) {
@@ -497,6 +499,8 @@ export default class Table extends PureComponent {
 
   saveInnerRef = ref => {
     this.innerRef = ref;
+
+    this.props.innerRef(ref);
   };
 
   render() {


### PR DESCRIPTION
> Note: It is currently available on table instance. i.e if you get the ref of table component, you can access the innerRef as this.table.innerRef.